### PR TITLE
fix: cron schedule

### DIFF
--- a/.github/workflows/html-to-markdown.yml
+++ b/.github/workflows/html-to-markdown.yml
@@ -2,7 +2,9 @@ name: HTML to Markdown
 
 on:
   schedule:
-    - cron: '*/1 * * * *'
+    # The shortest interval you can run scheduled workflows is once every 5 minutes.
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
+    - cron: '*/5 * * * *'
 
 defaults:
   run:


### PR DESCRIPTION
>The shortest interval you can run scheduled workflows is once every 5 minutes.

ref. https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule