### PR TITLE
feat: trigger GitHub actions with gas scheduler

### DIFF
--- a/.github/workflows/html-to-markdown.yml
+++ b/.github/workflows/html-to-markdown.yml
@@ -1,10 +1,10 @@
 name: HTML to Markdown
 
 on:
-  schedule:
-    # The shortest interval you can run scheduled workflows is once every 5 minutes.
-    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
-    - cron: '*/5 * * * *'
+  # NOTE: The scheduler for GitHub Actions can only be executed at a minimum interval of 5 minutes
+  # and does not reliably start processing every 5 minutes.
+  # Therefore, I am using the scheduler in Google Apps Script to initiate the job every minute.
+  # For this reason, I have not specified a cron expression here.
   workflow_dispatch:
 
 defaults:

--- a/README.md
+++ b/README.md
@@ -18,10 +18,12 @@ tree . -I node_modules
 │   │   ├── appsscript.json
 │   │   ├── auth.ts
 │   │   ├── clients
-│   │   │   └── chatgpt-client.ts
+│   │   │   ├── chatgpt-client.ts
+│   │   │   └── github-client.ts
 │   │   ├── fetch-from-spreadsheet.ts
 │   │   ├── filter-latest-summaries.ts
 │   │   ├── index.ts
+│   │   ├── invoke-cronjob.ts
 │   │   ├── log-error.ts
 │   │   ├── schema.ts
 │   │   ├── summarize.ts
@@ -39,10 +41,11 @@ tree . -I node_modules
 └── scripts
     └── bookmarklet
         ├── bookmarklet-formatter.sh
+        ├── sample_result.txt
         ├── webpage-summary-bookmarklet.js
         └── webpage-summary-bookmarklet.txt
 
-8 directories, 24 files
+8 directories, 27 files
 ```
 
 ## Setup
@@ -80,6 +83,10 @@ clasp open
 - OPENAI_API_KEY: Your OpenAI API Key
 - SPREADSHEET_ID: Your Spreadsheet ID
 - WEBPAGE_SUMMARIZER_API_KEY: Any string you generate for easy authentication in Google Apps Script
+- GITHUB_TOKEN: Your GitHub Personal Access Token
+- GITHUB_OWNER: Your GitHub username
+- GITHUB_REPO: Your GitHub repository name
+- GITHUB_WORKFLOW_ID: Your GitHub Actions workflow ID
 
 5. Prepare spreadsheet as follows
 

--- a/apis/src/clients/github-client.ts
+++ b/apis/src/clients/github-client.ts
@@ -1,0 +1,35 @@
+const GITHUB_BASE_URL = 'https://api.github.com';
+const GITHUB_TOKEN =
+  PropertiesService.getScriptProperties().getProperty('GITHUB_TOKEN');
+const GITHUB_OWNER =
+  PropertiesService.getScriptProperties().getProperty('GITHUB_OWNER');
+const GITHUB_REPO =
+  PropertiesService.getScriptProperties().getProperty('GITHUB_REPO');
+const GITHUB_WORKFLOW_ID =
+  PropertiesService.getScriptProperties().getProperty('GITHUB_WORKFLOW_ID');
+
+const triggerGitHubActionsJob = (): void => {
+  const response = UrlFetchApp.fetch(
+    `${GITHUB_BASE_URL}/repos/${GITHUB_OWNER}/${GITHUB_REPO}/actions/workflows/${GITHUB_WORKFLOW_ID}/dispatches`,
+    {
+      method: 'post',
+      headers: {
+        Authorization: `token ${GITHUB_TOKEN}`,
+        Accept: 'application/vnd.github.v3+json',
+      },
+      payload: JSON.stringify({
+        ref: 'master',
+      }),
+      muteHttpExceptions: true,
+    }
+  );
+
+  const status = response.getResponseCode();
+  const rawResponse = response.getContentText();
+
+  if (status !== 204) {
+    throw new Error(
+      `Failed to request to GitHub. status: ${status}, response: ${rawResponse}`
+    );
+  }
+};

--- a/apis/src/invoke-cronjob.ts
+++ b/apis/src/invoke-cronjob.ts
@@ -1,0 +1,5 @@
+const invokeCronjob = () => {
+  console.log('Starting cronjob...');
+  triggerGitHubActionsJob();
+  console.log('Finish invoking cronjob.');
+};

--- a/apis/src/triggers.ts
+++ b/apis/src/triggers.ts
@@ -2,11 +2,13 @@ const createTriggerForSummarizeFunction = () => {
   ScriptApp.newTrigger('summarize').timeBased().everyMinutes(1).create();
 };
 
-function deleteTriggerForSummarizeFunction() {
+const createTriggerForInvokeCronjobFunction = () => {
+  ScriptApp.newTrigger('invokeCronjob').timeBased().everyMinutes(1).create();
+};
+
+function deleteTriggers() {
   const triggers = ScriptApp.getProjectTriggers();
   triggers.forEach((trigger) => {
-    if (trigger.getHandlerFunction() === 'summarize') {
-      ScriptApp.deleteTrigger(trigger);
-    }
+    ScriptApp.deleteTrigger(trigger);
   });
 }


### PR DESCRIPTION
The scheduler for GitHub Actions can only be executed at a minimum interval of 5 minutes and does not reliably start processing every 5 minutes. Therefore, I am using the scheduler in Google Apps Script to initiate the job every minute. For this reason, I have not specified a cron expression here.